### PR TITLE
test(yargs-interactive): Add tests for each prompt option

### DIFF
--- a/src/is-args-provided.js
+++ b/src/is-args-provided.js
@@ -1,0 +1,9 @@
+/**
+ * Checks if the argument received is provided in the argument collection
+ * @param {Object} arg - The arg to check (e.g. `likesPizza`)
+ * @param {Object} processArgs - The collection of process arguments (e.g. `["--interactive", "--likesPizza=true"]`)
+ * @return {boolean} - Returns true if the argument is present in the collection of process arguments, false otherwise.
+ */
+module.exports = (arg, processArgs) => {
+  return processArgs.some((argProvided) => argProvided === `--${arg}` || argProvided.startsWith(`--${arg}=`));
+};

--- a/src/yargs-interactive.js
+++ b/src/yargs-interactive.js
@@ -2,33 +2,25 @@ const yargs = require('yargs');
 const interactiveMode = require('./interactive-mode');
 const filterObject = require('./filter-object');
 const isEmpty = require('./is-empty');
-
-const argsProvided = process.argv.slice(2);
-const isArgProvided = (arg) => argsProvided.some((argProvided) => argProvided === `--${arg}` || argProvided.startsWith(`--${arg}=`));
+const isArgProvided = require('./is-args-provided');
 
 // Set up yargs options
-let yargsInteractive = (processArgs = argsProvided, cwd) => {
+let yargsInteractive = (processArgs = process.argv.slice(2), cwd) => {
   const yargsConfig = yargs(processArgs, cwd);
 
   // Add interactive functionality
   yargsConfig.interactive = (options = {}) => {
     // Merge options sent by parameters with interactive option
-    const mergedOptions = Object.assign(
-      {},
-      options,
-      {
-        interactive: {
-          default: !!(options.interactive && options.interactive.default),
-          prompt: 'never',
-        }
+    const mergedOptions = Object.assign({}, options, {
+      interactive: {
+        default: !!(options.interactive && options.interactive.default),
+        prompt: 'never'
       }
-    );
+    });
 
     // Run yargs with interactive option
     // and get the requested arguments
-    const argv = yargsConfig
-      .options(mergedOptions)
-      .argv;
+    const argv = yargsConfig.options(mergedOptions).argv;
 
     // Filter options to prompt based on the "if-empty" property
     const interactiveOptions = filterObject(mergedOptions, (item, key) => {
@@ -44,7 +36,7 @@ let yargsInteractive = (processArgs = argsProvided, cwd) => {
 
       // Prompt items that are set with 'if-no-arg' and values were not send via command line parameters
       if (item.prompt === 'if-no-arg') {
-        return !isArgProvided(key);
+        return !isArgProvided(key, processArgs);
       }
 
       // Cases: item.prompt === "if-empty" or item.prompt undefined (fallbacks to "if-empty")
@@ -60,6 +52,5 @@ let yargsInteractive = (processArgs = argsProvided, cwd) => {
 
   return yargsConfig;
 };
-
 
 module.exports = yargsInteractive;

--- a/test/yargs-interactive.test.js
+++ b/test/yargs-interactive.test.js
@@ -10,6 +10,19 @@ function checkProperties(result, expectedValues = {}) {
   assert.equal(result.interactive, !!expectedValues.interactive, 'interactive');
 }
 
+function getOptionKeys({options, prompt, hasDefaultValue}) {
+  const checkDefaultValue = (item) => (hasDefaultValue && item.default) || (!hasDefaultValue && item.default === undefined);
+  return Object.keys(options).reduce((acc, key) => {
+    const item = options[key];
+    const shouldCheckDefaultValue = hasDefaultValue !== undefined;
+    if (item.prompt === prompt && ((shouldCheckDefaultValue && checkDefaultValue(item)) || !shouldCheckDefaultValue)) {
+      acc.push(key);
+    }
+
+    return acc;
+  }, []);
+}
+
 describe('yargsInteractive', () => {
   let result;
   let interactiveModeStub;
@@ -24,6 +37,7 @@ describe('yargsInteractive', () => {
 
   describe('with no interactive', () => {
     before(() => {
+      interactiveModeStub.resetHistory();
       result = yargsInteractive()
         .usage('$0 <command> [args]')
         .version()
@@ -42,12 +56,13 @@ describe('yargsInteractive', () => {
 
   describe('with no options', () => {
     before(() => {
+      interactiveModeStub.resetHistory();
       return yargsInteractive()
         .usage('$0 <command> [args]')
         .version()
         .help()
         .interactive()
-        .then((output) => result = output);
+        .then((output) => (result = output));
     });
 
     it('should return yargs default properties', () => {
@@ -76,12 +91,13 @@ describe('yargsInteractive', () => {
 
     describe('and no parameters', () => {
       before(() => {
+        interactiveModeStub.resetHistory();
         return yargsInteractive()
           .usage('$0 <command> [args]')
           .version()
           .help()
           .interactive(options)
-          .then((output) => result = output);
+          .then((output) => (result = output));
       });
 
       it('should return yargs default properties', () => {
@@ -99,13 +115,14 @@ describe('yargsInteractive', () => {
       let expectedParameters;
 
       before(() => {
+        interactiveModeStub.resetHistory();
         expectedParameters = {directory: 'abc', projectName: 'def'};
         return yargsInteractive(Object.keys(expectedParameters).map((key) => `--${key}=${expectedParameters[key]}`))
           .usage('$0 <command> [args]')
           .version()
           .help()
           .interactive(options)
-          .then((output) => result = output);
+          .then((output) => (result = output));
       });
 
       it('should return yargs default properties', () => {
@@ -121,12 +138,13 @@ describe('yargsInteractive', () => {
 
     describe('and interactive parameter', () => {
       before(() => {
+        interactiveModeStub.resetHistory();
         return yargsInteractive(`--interactive`)
           .usage('$0 <command> [args]')
           .version()
           .help()
           .interactive(options)
-          .then((output) => result = output);
+          .then((output) => (result = output));
       });
 
       it('should return yargs default properties', () => {
@@ -138,62 +156,16 @@ describe('yargsInteractive', () => {
       });
     });
 
-    describe('and interactive parameters with prompt option', () => {
-      let expectedParameters;
-
-      before(() => {
-        options = {
-          directory: {
-            type: 'input',
-            default: '.',
-            describe: 'Target directory',
-          },
-          projectName: {
-            type: 'input',
-            describe: 'Project name',
-            prompt: 'if-empty',
-          },
-          user: {
-            type: 'input',
-            describe: 'user',
-            prompt: 'never'
-          },
-          password: {
-            type: 'input',
-            describe: 'user',
-            prompt: 'always'
-          },
-        };
-
-        expectedParameters = {directory: 'abc', projectName: 'def'};
-        return yargsInteractive(Object.keys(expectedParameters).map((key) => `--${key}=${expectedParameters[key]}`))
-          .usage('$0 <command> [args]')
-          .version()
-          .help()
-          .interactive(options)
-          .then((output) => result = output);
-      });
-
-      it('should return yargs default properties', () => {
-        checkProperties(result);
-      });
-
-      it('should return options with values sent by parameter', () => {
-        Object.keys(options).forEach((key) => {
-          assert.equal(result[key], expectedParameters[key], key);
-        });
-      });
-    });
-
     describe('and interactive option', () => {
       before(() => {
+        interactiveModeStub.resetHistory();
         const optionsWithInteractive = Object.assign({}, options, {interactive: {default: true}});
         return yargsInteractive()
           .usage('$0 <command> [args]')
           .version()
           .help()
           .interactive(optionsWithInteractive)
-          .then((output) => result = output);
+          .then((output) => (result = output));
       });
 
       it('should return yargs default properties', () => {
@@ -202,6 +174,101 @@ describe('yargsInteractive', () => {
 
       it('should call interactive mode', () => {
         assert.equal(interactiveModeStub.called, true, 'interactive mode');
+      });
+    });
+  });
+
+  describe('with options using different prompt values', () => {
+    let yargsInteractiveArgs;
+    let promptedOptions;
+    let options;
+
+    before(() => {
+      interactiveModeStub.resetHistory();
+      yargsInteractiveArgs = [`--interactive`, `--option8='value'`];
+      options = {
+        option1: {type: 'input', describe: 'option1', default: '.', prompt: 'always'},
+        option2: {type: 'input', describe: 'option2', default: '.', prompt: 'never'},
+
+        // if-empty
+        option3: {type: 'input', describe: 'option3', prompt: 'if-empty'},
+        option4: {type: 'input', describe: 'option4', default: '.', prompt: 'if-empty'},
+
+        // no prompt (defaults to 'if-empty')
+        option5: {type: 'input', describe: 'option5'},
+        option6: {type: 'input', describe: 'option6'},
+
+        // if-no-arg
+        option7: {type: 'input', describe: 'option7', default: '.', prompt: 'if-no-arg'},
+        option8: {type: 'input', describe: 'option8', default: '.', prompt: 'if-no-arg'}
+      };
+
+      return yargsInteractive(yargsInteractiveArgs)
+        .usage('$0 <command> [args]')
+        .version()
+        .help()
+        .interactive(options)
+        .then((output) => {
+          result = output;
+          promptedOptions = interactiveModeStub.args[0][0];
+        });
+    });
+
+    it('should prompt options with prompt set as "always"', () => {
+      const optionKeys = getOptionKeys({options, prompt: 'always'});
+      optionKeys.forEach((key) => assert.ok(promptedOptions[key], `${key} not prompted`));
+    });
+
+    it('should not prompt options with prompt set as "never"', () => {
+      const optionKeys = getOptionKeys({options, prompt: 'never'});
+      optionKeys.forEach((key) => assert.ok(promptedOptions[key] === undefined, `${key} should not prompt`));
+    });
+
+    // if-empty
+
+    it('should prompt options with no value set and prompt set as "if-empty"', () => {
+      const optionKeys = getOptionKeys({options, prompt: 'if-empty', hasDefaultValue: false});
+      optionKeys.forEach((key) => assert.ok(promptedOptions[key], `${key} should prompt`));
+    });
+
+    it('should not prompt options with default value set and prompt set as "if-empty"', () => {
+      const optionKeys = getOptionKeys({options, prompt: 'if-empty', hasDefaultValue: true});
+      optionKeys.forEach((key) => assert.ok(promptedOptions[key] === undefined, `${key} should not prompt`));
+    });
+
+    // no prompt (defaults to 'if-empty')
+
+    it('should prompt options with no value set and prompt not set', () => {
+      const optionKeys = getOptionKeys({options, prompt: undefined});
+      optionKeys.forEach((key) => assert.ok(promptedOptions[key], `${key} should prompt`));
+    });
+
+    it('should not prompt options with default value set and prompt not set', () => {
+      const optionKeys = getOptionKeys({options, prompt: undefined, hasDefaultValue: false});
+      optionKeys.forEach((key) => assert.ok(promptedOptions[key], `${key} should prompt`));
+    });
+
+    // if-no-arg
+
+    it('should prompt options with no args and prompt set as "if-no-arg"', () => {
+      const optionKeys = getOptionKeys({options, prompt: 'if-no-arg'});
+      optionKeys.forEach((key) => {
+        const promptedOption = promptedOptions[key];
+        const optionSentByArgument = yargsInteractiveArgs.find((arg) => arg.startsWith(`--${key}`)) !== undefined;
+        if (!optionSentByArgument) {
+          assert.ok(promptedOption, `${key} should prompt`);
+        }
+      });
+    });
+
+    it('should not prompt options with value sent in args and prompt set as "if-no-arg"', () => {
+      const optionKeys = getOptionKeys({options, prompt: 'if-no-arg'});
+      optionKeys.forEach((key) => {
+        const promptedOption = promptedOptions[key];
+        const optionSentByArgument = yargsInteractiveArgs.find((arg) => arg.startsWith(`--${key}`)) !== undefined;
+        if (optionSentByArgument) {
+          assert.ok(promptedOption === undefined, `${key} should not prompt`);
+        }
       });
     });
   });


### PR DESCRIPTION
This PR does two things:

1. It add tests for all the different `prompt` values we support (including `if-no-arg`).
1. It refactors the **yargs-interactive.js** a little bit.

@iamturns please review the code and merge it in your branch in order to merge https://github.com/nanovazquez/yargs-interactive/pull/17 Thanks!